### PR TITLE
JEP-13 Object Manipulation Functions

### DIFF
--- a/jmespath/compat.py
+++ b/jmespath/compat.py
@@ -1,8 +1,8 @@
-import sys
 import inspect
-from itertools import zip_longest
 
+iteritems = dict.items
 
+map = map
 text_type = str
 string_type = str
 

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -2,6 +2,9 @@ import math
 import json
 
 from jmespath import exceptions
+from jmespath.compat import get_methods
+from jmespath.compat import iteritems
+from jmespath.compat import map
 from jmespath.compat import string_type as STRING_TYPE
 from jmespath.compat import get_methods
 
@@ -185,6 +188,10 @@ class Functions(metaclass=FunctionRegistry):
         else:
             return [arg]
 
+    @signature({'types': ['array']})
+    def _func_to_object(self, pairs):
+        return dict(pairs)
+
     @signature({'types': []})
     def _func_to_string(self, arg):
         if isinstance(arg, STRING_TYPE):
@@ -281,6 +288,10 @@ class Functions(metaclass=FunctionRegistry):
     def _func_sum(self, arg):
         return sum(arg)
 
+    @signature({'types': ['object']})
+    def _func_items(self, arg):
+        return list(map(list, iteritems(arg)))
+
     @signature({"types": ['object']})
     def _func_keys(self, arg):
         # To be consistent with .values()
@@ -345,6 +356,10 @@ class Functions(metaclass=FunctionRegistry):
             return max(array, key=keyfunc)
         else:
             return None
+
+    @signature({'types': ['array'], 'variadic': True})
+    def _func_zip(self, *arguments):
+        return list(map(list, zip(*arguments)))
 
     def _create_key_func(self, expref, allowed_types, function_name):
         def keyfunc(x):

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -6,7 +6,6 @@ from jmespath.compat import get_methods
 from jmespath.compat import iteritems
 from jmespath.compat import map
 from jmespath.compat import string_type as STRING_TYPE
-from jmespath.compat import get_methods
 
 
 # python types -> jmespath types

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -188,10 +188,6 @@ class Functions(metaclass=FunctionRegistry):
         else:
             return [arg]
 
-    @signature({'types': ['array']})
-    def _func_to_object(self, pairs):
-        return dict(pairs)
-
     @signature({'types': []})
     def _func_to_string(self, arg):
         if isinstance(arg, STRING_TYPE):
@@ -291,6 +287,10 @@ class Functions(metaclass=FunctionRegistry):
     @signature({'types': ['object']})
     def _func_items(self, arg):
         return list(map(list, iteritems(arg)))
+
+    @signature({'types': ['array']})
+    def _func_from_items(self, items):
+        return dict(items)
 
     @signature({"types": ['object']})
     def _func_keys(self, arg):

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -177,8 +177,8 @@
       "error": "invalid-type"
     },
     {
-      "expression": "items(objects)",
-      "result": [["foo", "bar"], ["bar", "baz"]]
+      "expression": "sort_by(items(objects), &[0])",
+      "result": [["bar", "baz"], ["foo", "bar"]]
     },
     {
       "expression": "items(empty_hash)",

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -12,7 +12,7 @@
     "empty_list": [],
     "empty_hash": {},
     "objects": {"foo": "bar", "bar": "baz"},
-    "pairs": [["a", "first"], ["b", "second"], ["c", "third"]],
+    "items": [["a", "first"], ["b", "second"], ["c", "third"]],
     "null_key": null
   },
   "cases": [
@@ -187,6 +187,10 @@
     {
       "expression": "items(numbers)",
       "error": "invalid-type"
+    },
+    {
+      "expression": "from_items(items)",
+      "result": {"a": "first", "b": "second", "c": "third"}
     },
     {
       "expression": "length('abc')",
@@ -491,10 +495,6 @@
     {
       "expression": "to_array(false)",
       "result": [false]
-    },
-    {
-      "expression": "to_object(pairs)",
-      "result": {"a": "first", "b": "second", "c": "third"}
     },
     {
       "expression": "to_string('foo')",

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -12,6 +12,7 @@
     "empty_list": [],
     "empty_hash": {},
     "objects": {"foo": "bar", "bar": "baz"},
+    "pairs": [["a", "first"], ["b", "second"], ["c", "third"]],
     "null_key": null
   },
   "cases": [
@@ -176,6 +177,18 @@
       "error": "invalid-type"
     },
     {
+      "expression": "items(objects)",
+      "result": [["foo", "bar"], ["bar", "baz"]]
+    },
+    {
+      "expression": "items(empty_hash)",
+      "result": []
+    },
+    {
+      "expression": "items(numbers)",
+      "error": "invalid-type"
+    },
+    {
       "expression": "length('abc')",
       "result": 3
     },
@@ -189,7 +202,7 @@
     },
     {
       "expression": "length(@)",
-      "result": 12
+      "result": 13
     },
     {
       "expression": "length(strings[0])",
@@ -480,6 +493,10 @@
       "result": [false]
     },
     {
+      "expression": "to_object(pairs)",
+      "result": {"a": "first", "b": "second", "c": "third"}
+    },
+    {
       "expression": "to_string('foo')",
       "result": "foo"
     },
@@ -588,6 +605,18 @@
       "comment": "function projection on single arg function",
       "expression": "array[].to_number(@)",
       "result": [-1, 3, 4, 5, 100]
+    },
+    {
+      "expression": "zip(strings, numbers)",
+      "result": [["a", -1], ["b", 3], ["c", 4]]
+    },
+    {
+      "expression": "zip(strings, numbers, decimals)",
+      "result": [["a", -1, 1.01], ["b", 3, 1.2], ["c", 4, -1.5]]
+    },
+    {
+      "expression": "zip(str)",
+      "error": "invalid-type"
     }
   ]
 }, {


### PR DESCRIPTION
Implements [JEP-13 Object Manipulation Functions] from [JMESPath Community](https://jmespath.site/main).
See spec for [`items`](https://jmespath.site/main/#func-items), [`from_items`](https://jmespath.site/main/#func-from_items) and [`zip`](https://jmespath.site/main/#func-zip) functions.

This PR leverages #105 work performed by @jstewmon.
It includes an additional commit for updated `jmespath/compat.py` file.