### PR TITLE
JEP-15 String Slices

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -277,6 +277,17 @@ class TreeInterpreter(Visitor):
 
     def visit_projection(self, node, value):
         base = self.visit(node['children'][0], value)
+
+        allow_string = False
+        first_child = node['children'][0]
+        if first_child['type'] == 'index_expression':
+            nested_children = first_child['children']
+            if len(nested_children) > 1 and nested_children[1]['type'] == 'slice':
+                allow_string = True
+
+        if isinstance(base, string_type) and allow_string:
+            return base
+
         if not isinstance(base, list):
             return None
         collected = []

--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -216,6 +216,12 @@ class TreeInterpreter(Visitor):
         return result
 
     def visit_slice(self, node, value):
+        if isinstance(value, string_type):
+            start = node['children'][0]
+            end = node['children'][1]
+            step = node['children'][2]
+            return value[start:end:step]
+
         if not isinstance(value, list):
             return None
         s = slice(*node['children'])

--- a/tests/compliance/slice.json
+++ b/tests/compliance/slice.json
@@ -184,4 +184,12 @@
       "result": []
     }
   ]
+}, {
+  "given": null,
+  "cases": [
+    {
+      "expression": "'e\u0301le\u0301ment'[::-1]",
+      "result": "tnem\u0301el\u0301e"
+    }
+  ]
 }]


### PR DESCRIPTION
This PR implements [JEP-15 String Slices](https://github.com/jmespath-community/jmespath.spec/blob/main/jep-015-string-slices.md) from [JMESPath Community](https://jmespath.site/main).

This PR proves surprisingly hard to design as the JMESPath AST hard-wires slices inside a projection.

Therefore, there is no easy way to know if we should keep the result of evaluating children if they do not return an array that would be illegal before this PR.

Consider the following two expressions:

- `` foo[*].bar `` the grammar specifies this as a `sub-expression` but the Python implementation produces the following AST instead:

```json
{
  "type": "projection",
  "children": [
    {"type": "field", "value": "foo"},
    {"type": "field", "value": "bar"}
  ]
}
```

Contrast with the following expression:

- `` foo[::-1] `` The grammar specifies this as an `index-expression` and, close enough, the Python implementation produces the following AST:

```json
{
  "type": "projection",
  "children": [
    {
      "type": "index_expression",
      "children": [
        {"type": "field", "value": "foo"},
        {"type": "slice", "children": [ null, null, -1 ]}
      ]
    },
    {"type": "identity"}
  ]
}
```

In both cases, we see that there is an additional "projection" AST node that wraps the parsed construct and is used for evaluation.

I had to resort to special-case `visit_projection` with the exact shape of the AST to recognize slices and accept string results. 

```python
        allow_string = False
        first_child = node['children'][0]
        if first_child['type'] == 'index_expression':
            nested_children = first_child['children']
            if len(nested_children) > 1 and nested_children[1]['type'] == 'slice':
                allow_string = True

        if isinstance(base, string_type) and allow_string:
            return base
```

I think there should be a better way. 😥
